### PR TITLE
Fix invalid Docker port (22825 instead of 122825)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This is a static frontend SPA: a personal portfolio/blog built with Vite + React
 
 Standard scripts live in `package.json`; run them with Bun (e.g. `bun run dev`). Notes:
 
-- `bun run dev` serves on port `2718` (`bun run start` uses port `122825` via `PORT` env).
+- `bun run dev` serves on port `2718` (`bun run start` uses port `22825` via `PORT` env).
 - `vite.config.ts` only allows the extra host `local.iyansr.id`; use `localhost` (or add `--host`) when testing locally.
 - `bun run lint` (Biome) currently reports pre-existing warnings and one `noExplicitAny` error in `src/lib/post.ts` / `src/routes/blog/$slug.tsx`. This is unrelated to environment setup — do not "fix" it as part of setup.
 - `bun run test` (Vitest) exits non-zero with "No test files found" because the template has no tests yet; this is expected, not a setup failure.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN bun run build
 FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
-ENV PORT=122825
+ENV PORT=22825
 COPY --from=builder /app/.output ./.output
-EXPOSE 122825
+EXPOSE 22825
 CMD ["node", ".output/server/index.mjs"]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 2718 --no-open",
-    "start": "PORT=122825 node .output/server/index.mjs",
+    "start": "PORT=22825 node .output/server/index.mjs",
     "build": "vite build && tsc --noEmit",
     "serve": "vite preview",
     "test": "vitest run",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Dokploy/Docker build fails with:

```
invalid containerPort: 122825
```

Port **122825** is invalid — TCP ports must be between **1** and **65535**.

## Fix

Use port **22825** instead (valid, avoids Dokploy UI on 3000).

## Dokploy

Set the container port to **22825** in your application settings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fedab38c-098c-4f0c-8af2-d6c78990fda1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fedab38c-098c-4f0c-8af2-d6c78990fda1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

