### PR TITLE
Fix page refresh on /blog and other nested routes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,8 @@ server {
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
 
     location / {
-        try_files $uri $uri/ $uri/index.html /index.html;
+        # Try exact file, then nested index.html (e.g. /blog -> /blog/index.html),
+        # then directory, then SPA fallback.
+        try_files $uri $uri/index.html $uri/ /index.html;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Client-side navigation to `/blog` works, but **refreshing** on `/blog` fails.

## Cause

nginx `try_files` order was:

```
$uri $uri/ $uri/index.html
```

For `/blog`, nginx tried a trailing-slash redirect before checking `/blog/index.html`, which breaks on static hosting behind Cloudflare Tunnel.

## Fix

```
$uri $uri/index.html $uri/ /index.html
```

Now `/blog` resolves directly to `/blog/index.html` (the prerendered page).

## After merge

Redeploy on Dokploy so the updated `nginx.conf` is picked up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fedab38c-098c-4f0c-8af2-d6c78990fda1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fedab38c-098c-4f0c-8af2-d6c78990fda1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

