### PR TITLE
Fix lazy route chunk 404 by serving assets with nginx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,9 @@ This is a static frontend site built with Vite + React 19 + TanStack Start (file
 
 Standard scripts live in `package.json`; run them with pnpm (e.g. `pnpm dev`). Notes:
 
-- `pnpm dev` serves on port `2718` (`pnpm start` runs the Nitro server on port `22825`).
-- Production Docker runs `node .output/server/index.mjs` directly on port `22825` (`HOST=0.0.0.0`).
+- `pnpm dev` serves on port `2718` (`pnpm start` previews the build on port `22825`).
+- Production Docker serves prerendered static files from `.output/public` via **nginx** on port `22825`.
+- HTML is served with `no-cache`; hashed `/assets/*` files are cached long-term.
 - `vite.config.ts` only allows the extra host `local.iyansr.id`; use `localhost` (or add `--host`) when testing locally.
 - `pnpm lint` (Biome) currently reports pre-existing warnings and one `noExplicitAny` error in `src/lib/post.ts` / `src/routes/blog/$slug.tsx`. This is unrelated to environment setup — do not "fix" it as part of setup.
 - `pnpm test` (Vitest) exits non-zero with "No test files found" because the template has no tests yet; this is expected, not a setup failure.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,7 @@ ARG SITE_URL=https://iyansr.id
 ENV SITE_URL=$SITE_URL
 RUN env -u PORT -u NITRO_PORT pnpm run build
 
-FROM node:22-alpine AS runner
-WORKDIR /app
-ENV NODE_ENV=production
-ENV PORT=22825
-ENV HOST=0.0.0.0
-ENV NITRO_HOST=0.0.0.0
-COPY --from=builder /app/.output ./.output
+FROM nginx:alpine AS runner
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/.output/public /usr/share/nginx/html
 EXPOSE 22825
-CMD ["node", ".output/server/index.mjs"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,22 @@
+server {
+    listen 22825;
+    listen [::]:22825;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+
+    # Hashed build assets — cache aggressively
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # HTML pages — always revalidate (avoids stale JS chunk references after deploy)
+    location / {
+        add_header Cache-Control "no-cache, must-revalidate";
+        try_files $uri $uri/index.html $uri/ /index.html;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite dev --port 2718 --no-open",
-    "start": "PORT=22825 HOST=0.0.0.0 node .output/server/index.mjs",
+    "start": "vite preview --host 127.0.0.1 --port 22825",
     "build": "vite build && tsc --noEmit",
     "serve": "vite preview",
     "test": "vitest run",

--- a/src/lib/chunk-reload.ts
+++ b/src/lib/chunk-reload.ts
@@ -1,0 +1,20 @@
+/** Reload the page when a lazy-loaded chunk fails (stale cache after deploy). */
+export function registerChunkReloadHandler() {
+  if (typeof window === 'undefined') return;
+
+  window.addEventListener('vite:preloadError', () => {
+    window.location.reload();
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    const message =
+      event.reason instanceof Error
+        ? event.reason.message
+        : String(event.reason ?? '');
+
+    if (message.includes('Failed to fetch dynamically imported module')) {
+      event.preventDefault();
+      window.location.reload();
+    }
+  });
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -3,6 +3,9 @@ import { createRouter } from '@tanstack/react-router';
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query';
 
 import { routeTree } from './routeTree.gen';
+import { registerChunkReloadHandler } from './lib/chunk-reload';
+
+registerChunkReloadHandler();
 
 export function getRouter() {
   const queryClient = new QueryClient({

--- a/src/routes/open-source.tsx
+++ b/src/routes/open-source.tsx
@@ -5,7 +5,6 @@ import { BlurFade } from '@/components/magicui/blur-fade';
 import { useOpenSourceContributions } from '@/hooks/opensource-contrib';
 
 export const Route = createFileRoute('/open-source')({
-  ssr: false,
   component: RouteComponent,
   head: () => ({
     meta: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Navigating to `/open-source` fails with:
```
Failed to fetch dynamically imported module: .../assets/open-source-*.js
```
Refresh works because the full HTML page loads differently.

## Root cause

The **Nitro Node server does not serve `/assets/*.js` correctly** — requests return HTML 404 instead of JavaScript files. Client-side navigation then fails when loading lazy route chunks.

Verified: `curl -I https://iyansr.id/assets/open-source-*.js` → **404**

## Fix

1. **nginx serves `.output/public` statically** — `/assets/` files served correctly
2. **Cache headers:**
   - `/assets/*` → `max-age=31536000, immutable`
   - HTML pages → `no-cache` (prevents stale chunk references after deploy)
3. **Removed `ssr: false`** on open-source route
4. **Auto-reload** on stale dynamic import failure (safety net after deploys)

## After merge

Redeploy on Dokploy. Purge Cloudflare cache once, then test:
- Home → click Open Source (no error)
- Hard refresh on `/open-source`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fedab38c-098c-4f0c-8af2-d6c78990fda1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fedab38c-098c-4f0c-8af2-d6c78990fda1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

