### PR TITLE
Fix /open-source client navigation (no nginx)

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,0 +1,14 @@
+import '@/lib/chunk-reload';
+
+import { StrictMode, startTransition } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { StartClient } from '@tanstack/react-start/client';
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <StartClient />
+    </StrictMode>,
+  );
+});

--- a/src/lib/chunk-reload.ts
+++ b/src/lib/chunk-reload.ts
@@ -1,0 +1,22 @@
+/** Reload the page when a lazy-loaded chunk fails (stale cache after deploy). */
+export function registerChunkReloadHandler() {
+  if (typeof window === 'undefined') return;
+
+  window.addEventListener('vite:preloadError', () => {
+    window.location.reload();
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    const message =
+      event.reason instanceof Error
+        ? event.reason.message
+        : String(event.reason ?? '');
+
+    if (message.includes('Failed to fetch dynamically imported module')) {
+      event.preventDefault();
+      window.location.reload();
+    }
+  });
+}
+
+registerChunkReloadHandler();

--- a/src/routes/open-source.tsx
+++ b/src/routes/open-source.tsx
@@ -5,7 +5,6 @@ import { BlurFade } from '@/components/magicui/blur-fade';
 import { useOpenSourceContributions } from '@/hooks/opensource-contrib';
 
 export const Route = createFileRoute('/open-source')({
-  ssr: false,
   component: RouteComponent,
   head: () => ({
     meta: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,21 @@ export default defineConfig({
     }),
     react(),
     // Force Node.js server output for consistent production builds.
-    nitro({ preset: 'node-server' }),
+    nitro({
+      preset: 'node-server',
+      routeRules: {
+        '/assets/**': {
+          headers: {
+            'cache-control': 'public, max-age=31536000, immutable',
+          },
+        },
+        '/**': {
+          headers: {
+            'cache-control': 'no-cache',
+          },
+        },
+      },
+    }),
   ],
   preview: {
     host: '127.0.0.1',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes client-side navigation to `/open-source` failing with `Failed to fetch dynamically imported module` while keeping the existing **Node server** deployment (no nginx).

## Root cause

- `/open-source` had `ssr: false`, creating a client-only lazy-loaded chunk on navigation from `/`.
- After deploy, browsers/Cloudflare could serve cached HTML referencing old chunk hashes → dynamic import 404.

## Changes

- **Remove `ssr: false`** from `open-source.tsx` so the route is SSR/prerendered like other pages.
- **Add `src/lib/chunk-reload.ts`** — auto-reloads on stale dynamic import failures (safety net after deploy).
- **Add `src/client.tsx`** — wires chunk-reload into the client entry.
- **Add Nitro `routeRules`** — HTML `no-cache`, hashed assets `immutable` (prevents stale chunk references).

## Unchanged

- Dockerfile still runs `node .output/server/index.mjs` on port 22825 — no nginx.

## After merge

Redeploy on Dokploy and purge Cloudflare cache for `iyansr.id` once so clients pick up fresh HTML.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fedab38c-098c-4f0c-8af2-d6c78990fda1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fedab38c-098c-4f0c-8af2-d6c78990fda1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

